### PR TITLE
Add OO back to the GitHub links

### DIFF
--- a/src/github.html
+++ b/src/github.html
@@ -28,6 +28,10 @@
             <p>SPD Lookup Service</p>
             <p class="subtitle">The Go backend to 1-312-hows-my-driving</p>
         </a>
+        <a href="https://github.com/SeattleDSA/OpenOversight/">
+            <p>OpenOversight</p>
+            <p class="subtitle">A fork of the Lucy Parsons Labs project for the Salish Sea</p>
+        </a>
         <a href="https://github.com/SeattleDSA/pra-request-tracker/">
             <p>Public Records Act Request Tracker</p>
             <p class="subtitle">An original project for tracking PRA requests</p>


### PR DESCRIPTION
Reverts SeattleDSA/techbloc-directory#7