### PR TITLE
Add label sync workflow and shared label definition

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,27 @@
+- name: "project: data publicity"
+  color: "#E000AC"
+  description: Related to sharing the data used for our applications publicly
+
+- name: "project: ETL"
+  color: "#E000AC"
+  description: Related to setting up/maintaining ETL for projects
+
+- name: "project: maintenance"
+  color: "#E000AC"
+  description: Related to regular maintenance for our projects
+
+- name: "project: mastodon"
+  color: "#E000AC"
+  description: Related to moving projects from Twitter to Mastodon
+
+- name: "project: new departments"
+  color: "#E000AC"
+  description: Related to adding data for new departments
+
+- name: "project: new services"
+  color: "#E000AC"
+  description: Related to spinning up new services
+
+- name: "project: OO enhancements"
+  color: "#E000AC"
+  description: Related to new enhancements to OpenOversight

--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -1,27 +1,30 @@
 name: Label sync
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *" # at 00:00
+    workflow_dispatch:
+    schedule:
+        - cron: "0 0 * * *" # at 00:00
 
 jobs:
-  sync_labels:
-      - uses: actions/checkout@v3
-      - name: Label Sync Action
-        uses: srealmoreno/label-sync-action@v1.0.2
-        with:
-            token: ${{ secrets.ACCESS_TOKEN }}
-            clean-labels: false
-            repositories: |
-                OrcaCollective/OpenOversight
-                OrcaCollective/1-312-hows-my-driving
-                OrcaCollective/techbloc-airflow
-                OrcaCollective/spd-data-watch
-                OrcaCollective/techbloc-directory
-                OrcaCollective/pra-request-tracker
-                OrcaCollective/jils-monitor
-                OrcaCollective/spd-lookup
-                OrcaCollective/not911.me
-                OrcaCollective/radio-chaser
-                OrcaCollective/umbrella-openmhz-encrypted
+    sync_labels:
+        name: Sync labels
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Label Sync Action
+              uses: srealmoreno/label-sync-action@v1.0.2
+              with:
+                  token: ${{ secrets.ACCESS_TOKEN }}
+                  clean-labels: false
+                  repositories: |
+                      OrcaCollective/OpenOversight
+                      OrcaCollective/1-312-hows-my-driving
+                      OrcaCollective/techbloc-airflow
+                      OrcaCollective/spd-data-watch
+                      OrcaCollective/techbloc-directory
+                      OrcaCollective/pra-request-tracker
+                      OrcaCollective/jils-monitor
+                      OrcaCollective/spd-lookup
+                      OrcaCollective/not911.me
+                      OrcaCollective/radio-chaser
+                      OrcaCollective/umbrella-openmhz-encrypted

--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -1,0 +1,27 @@
+name: Label sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # at 00:00
+
+jobs:
+  sync_labels:
+      - uses: actions/checkout@v3
+      - name: Label Sync Action
+        uses: srealmoreno/label-sync-action@v1.0.2
+        with:
+            token: ${{ secrets.ACCESS_TOKEN }}
+            clean-labels: false
+            repositories: |
+                OrcaCollective/OpenOversight
+                OrcaCollective/1-312-hows-my-driving
+                OrcaCollective/techbloc-airflow
+                OrcaCollective/spd-data-watch
+                OrcaCollective/techbloc-directory
+                OrcaCollective/pra-request-tracker
+                OrcaCollective/jils-monitor
+                OrcaCollective/spd-lookup
+                OrcaCollective/not911.me
+                OrcaCollective/radio-chaser
+                OrcaCollective/umbrella-openmhz-encrypted

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm files
+.idea/


### PR DESCRIPTION
This PR adds a label sync action for sharing labels across all repos. This is run daily or on-demand. See the label docs for more info: https://github.com/marketplace/actions/label-sync-action
