### PR TITLE
Add sync across repositories

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,4 @@
+# Project labels
 - name: "project: data publicity"
   color: "#E000AC"
   description: Related to sharing the data used for our applications publicly
@@ -25,3 +26,20 @@
 - name: "project: OO enhancements"
   color: "#E000AC"
   description: Related to new enhancements to OpenOversight
+
+# Dependency labels
+- name: "pip"
+  color: "#C2E0C6"
+  description: Python dependency changes
+
+- name: "npm"
+  color: "#4F4888"
+  description: Node.js dependency changes
+
+- name: "docker/env"
+  color: "#006B75"
+  description: Docker, environment, or CI changes
+
+- name: "github-actions"
+  color: "#1D76DB"
+  description: GitHub Action dependency changes

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,36 @@
+# Configuration file for the action `BetaHuhn/repo-file-sync-action`
+# Docs: https://github.com/BetaHuhn/repo-file-sync-action
+# Workflow: Meta file sync
+
+group:
+    - repos: |
+          OrcaCollective/1-312-hows-my-driving
+          OrcaCollective/techbloc-airflow
+          OrcaCollective/techbloc-directory
+          OrcaCollective/spd-data-watch
+          OrcaCollective/spd-lookup
+          OrcaCollective/radio-chaser
+      files:
+          - source: templates/dependabot.yml.jinja2
+            target: .github/dependabot.yml
+            template:
+                python: true
+                docker: true
+
+    - repos: |
+          OrcaCollective/OpenOversight
+      files:
+          - source: templates/dependabot.yml.jinja2
+            target: .github/dependabot.yml
+            template:
+                python: true
+                docker: true
+                npm: true
+
+    - repos: |
+          OrcaCollective/techbloc-directory
+      files:
+          - source: templates/dependabot.yml.jinja2
+            target: .github/dependabot.yml
+            template: true
+

--- a/.github/workflows/sync_meta.yml
+++ b/.github/workflows/sync_meta.yml
@@ -1,0 +1,22 @@
+name: Meta file sync
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "0 0 * * *"
+    push:
+        branches:
+            - main
+
+jobs:
+    sync_meta:
+        name: Sync meta files
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Run file sync
+              uses: BetaHuhn/repo-file-sync-action@v1
+              with:
+                  GH_PAT: ${{ secrets.ACCESS_TOKEN }}

--- a/templates/dependabot.yml.jinja2
+++ b/templates/dependabot.yml.jinja2
@@ -1,0 +1,37 @@
+---
+version: 2
+updates:
+    {% if python | default(false) %}
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      labels:
+          - "dependency"
+          - "pip"
+    {% endif %}
+    {% if docker | default(false) %}
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      labels:
+          - "dependency"
+          - "docker/env"
+    {% endif %}
+    {% if npm | default(false) %}
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      labels:
+          - "dependency"
+          - "npm"
+    {% endif %}
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      labels:
+          - "dependency"
+          - "github-actions"


### PR DESCRIPTION
This PR adds a sync action which _should_ sync dependabot files across repositories. It also adds some new labels for dependencies which are synced.
