### PR TITLE
Add note about sync for downstream repos

### DIFF
--- a/templates/dependabot.yml.jinja2
+++ b/templates/dependabot.yml.jinja2
@@ -1,3 +1,6 @@
+# NOTE: This file is synced from https://github.com/OrcaCollective/techbloc-directory
+# Please see the .github/sync.yml file for sync information.
+# (Note for maintainers, quarterly is not supported yet: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval)
 ---
 version: 2
 updates:


### PR DESCRIPTION
Adding a small note for downstream repos so we can easily tell which files are synced. I also wanted to change the interval to `quarterly` but apparently that's not an option yet q_q
